### PR TITLE
Allow manually starting a possume via .handle('_start')

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,8 +30,16 @@ function assertCfg(cfg) {
     }
 }
 
-function assertStarted(){
-    if(!this.started) {
+function assertStarted(inputType) {
+    if (this.started) {
+        return
+    }
+    // special case: if this consumer is manually handling
+    // _start on a possum, delegate to our internal api
+    if (inputType && inputType === '_start') {
+        return this.start()
+    }
+    if (!this.started) {
         throw new Error('This possum has not been `start`ed.')
     }
 }
@@ -250,7 +258,7 @@ function possum(cfg) {
     var handler = stampit()
         .methods({
             handle: function(inputType, msg) {
-                assertStarted.call(this)
+                assertStarted.call(this, inputType)
                 var message = command({
                     inputType: inputType
                     ,state: this.state

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "possum",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "I am able. Evented State Machine.",
   "main": "index.js",
   "directories": {

--- a/test/possum-spec.js
+++ b/test/possum-spec.js
@@ -77,7 +77,7 @@ describe('Possum',function(){
             })
         })
     })
-    describe('when started',function(){
+    describe('when started via the api',function(){
         var events
         beforeEach(function(){
             events = []
@@ -111,7 +111,34 @@ describe('Possum',function(){
         })
 
     })
-
+    describe('when started manually', function() {
+        beforeEach(function () {
+            sut = possum({
+                initialState: 'uninitialized'
+                , namespace: 'foo'
+                , states: {
+                    'uninitialized': {}
+                    , 'initialized': {}
+                }
+            })
+            .create()
+        })
+        beforeEach(function () {
+            return sut.handle('_start', {
+                toState: 'uninitialized'
+            })
+        })
+        it('should be started', function() {
+           sut.started.should.be.true
+        })
+        it('should be on initialState',function(){
+            sut.state.should.equal('uninitialized')
+        })
+        it('should have an undefined priorState',function(){
+            sut.should.contain.keys('priorState')
+            expect(sut.priorState).to.be.undefined
+        })
+    })
     describe('when transitioning',function(){
         var events
         describe('given transition to current state',function(){
@@ -639,12 +666,13 @@ describe('Possum',function(){
                 .should.throw(/This possum has not been `start`ed/)
 
         })
-        it('should throw on handle',function(){
+        it('should throw on any non "_start" handle', function(){
             sut.handle.bind(sut)
                 .should.throw(/This possum has not been `start`ed/)
-
         })
-
+        it('should allow handling "_start" manually', function () {
+            sut.handle.bind(sut, '_start')
+                .should.not.throw()
+        })
     })
-
 })


### PR DESCRIPTION
To permit event-sourcing with possum, consumers can now manually start a
possum instance (i.e. from a streamed event) and not have to worry about
consuming the .start() api.

possum.handle('_start', { toState: 'theDefinedInitialState' })
